### PR TITLE
fix: prefer kokoro submodule over pip-installed package in test_inference.py

### DIFF
--- a/scripts/test_inference.py
+++ b/scripts/test_inference.py
@@ -27,6 +27,12 @@ import argparse
 import sys
 from pathlib import Path
 
+# Prefer the kokoro submodule over any pip-installed kokoro package
+_repo_root = Path(__file__).resolve().parents[1]
+_kokoro_submodule = _repo_root / "kokoro"
+if _kokoro_submodule.exists() and str(_kokoro_submodule) not in sys.path:
+    sys.path.insert(0, str(_kokoro_submodule))
+
 # Standard German phonetic test set — covers all major pronunciation challenges
 TEST_SENTENCES = [
     # 1. Umlauts (ä, ö, ü) and sch


### PR DESCRIPTION
## Problem

After the submodule refactor (#16), `test_inference.py` picks up the pip-installed `kokoro` package (upstream, no German support) instead of the `semidark/kokoro` submodule. This causes silent noise output with no error message.

Reported in discussion #16.

## Fix

Add a `sys.path.insert` at the top of `test_inference.py` that prefers the local submodule when it exists:

```python
_repo_root = Path(__file__).resolve().parents[1]
_kokoro_submodule = _repo_root / "kokoro"
if _kokoro_submodule.exists() and str(_kokoro_submodule) not in sys.path:
    sys.path.insert(0, str(_kokoro_submodule))
```

Only activates when the submodule is present — no effect on environments without it.

## Test

Verified on RunPod (A40) with `epoch_1st_00003.pth` checkpoint — produces correct German audio after fix.