### PR TITLE
Improve German frontend normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,39 @@ cd kokoro-deutsch
 uv sync
 ```
 
+## German Frontend
+
+This repository also contains `kokoro_de`, a small German frontend layer for Kokoro.
+
+- Adds a repository-local German normalization layer for dates, times, euro amounts, percentages, selected units, ordinals, and common TTS/ML acronyms
+- Keeps `espeak-de` as the default path and applies overrides only where needed
+- Improves span-based matching for real-world spellings such as multi-word names and symbol forms
+- Provides unit tests for the frontend layer
+
+Example:
+
+```python
+from kokoro_de import phonemize
+
+print(phonemize("Louis Vuitton auf Disney+"))
+```
+
+```python
+from kokoro_de.pipeline import KokoroDEPipeline
+
+pipeline = KokoroDEPipeline(lang_code="de", model=model)
+for result in pipeline("Prime Video läuft auf dem iPad.", voice="df_voice"):
+    audio = result.audio
+```
+
+Frontend tests:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+`KokoroDEPipeline` requires upstream `kokoro`. In a normal install it uses the published `kokoro` package; in a source checkout it can also fall back to the local `kokoro/` submodule.
+
 ## Repository Layout
 
 ```text
@@ -82,6 +115,8 @@ scripts/             # Dataset prep, voicepack extraction, inference testing
 configs/             # Training config(s)
 docs/                # Training guide, troubleshooting, architecture notes
 training/            # Local training artifacts metadata (audio excluded)
+kokoro_de/           # German frontend package
+tests/               # Frontend unit tests
 ```
 
 ## Contributing

--- a/kokoro_de/__init__.py
+++ b/kokoro_de/__init__.py
@@ -1,0 +1,27 @@
+"""German frontend helpers for Kokoro TTS."""
+
+from .router import Router, Token, route, phonemize
+from .overrides import (
+    EN_OVERRIDES,
+    DE_FOREIGN,
+    BRAND_OVERRIDES,
+    normalize_for_lookup,
+    override_for,
+)
+from .normalizer import normalize_text_de
+
+try:
+    from .pipeline import KokoroDEPipeline
+except ImportError:
+    KokoroDEPipeline = None
+
+__version__ = "0.3.0"
+
+__all__ = [
+    "Router", "Token", "route", "phonemize",
+    "KokoroDEPipeline",
+    "EN_OVERRIDES", "DE_FOREIGN", "BRAND_OVERRIDES",
+    "normalize_text_de",
+    "normalize_for_lookup",
+    "override_for",
+]

--- a/kokoro_de/normalizer.py
+++ b/kokoro_de/normalizer.py
@@ -1,0 +1,295 @@
+"""
+Lightweight German text normalization used before routing into G2P.
+
+This is intentionally conservative. It handles a small set of high-value cases
+locally so the repo does not depend on an external German-normalization fork.
+"""
+
+from __future__ import annotations
+
+import re
+
+_MONTHS = {
+    1: "januar",
+    2: "februar",
+    3: "märz",
+    4: "april",
+    5: "mai",
+    6: "juni",
+    7: "juli",
+    8: "august",
+    9: "september",
+    10: "oktober",
+    11: "november",
+    12: "dezember",
+}
+
+_ABBREVIATIONS = {
+    r"\bz\.\s?B\.": "zum beispiel",
+    r"\bu\.\s?a\.": "unter anderem",
+    r"\busw\.": "und so weiter",
+    r"\bca\.": "circa",
+    r"\bDr\.": "Doktor",
+    r"\bProf\.": "Professor",
+    r"\bGmbH\b": "Gesellschaft mit beschränkter Haftung",
+}
+_LETTER_ACRONYMS = {
+    "AI": "a i",
+    "API": "a p i",
+    "CPU": "c p u",
+    "GPU": "g p u",
+    "KI": "k i",
+    "LLM": "l l m",
+    "NLP": "n l p",
+    "TTS": "t t s",
+    "UI": "u i",
+    "UX": "u x",
+}
+
+_DATE_WITH_AM_RE = re.compile(r"\bam\s+(\d{1,2})\.(\d{1,2})\.(\d{2,4})\b", flags=re.IGNORECASE)
+_DATE_RE = re.compile(r"\b(\d{1,2})\.(\d{1,2})\.(\d{2,4})\b")
+_TIME_RE = re.compile(r"\b(\d{1,2}):(\d{2})\b")
+_EURO_RE = re.compile(r"(?<!\w)(\d+(?:[.,]\d{1,2})?)\s*€|€\s*(\d+(?:[.,]\d{1,2})?)")
+_DECIMAL_RE = re.compile(r"\b(\d+),(\d+)\b")
+_PERCENT_RE = re.compile(r"\b(\d+(?:,\d+)?)\s*%")
+_UNIT_RE = re.compile(
+    r"\b(\d+(?:,\d+)?)\s*(km|kg|cm|mm|khz|mhz|ghz|hz|gb|tb|mb|ms|s|m|°c)\b",
+    flags=re.IGNORECASE,
+)
+_ORDINAL_RE = re.compile(r"\b(\d+)\.")
+_ACRONYM_RE = re.compile(r"\b(?:AI|API|CPU|GPU|KI|LLM|NLP|TTS|UI|UX)\b")
+_VERSION_RE = re.compile(r"\bv(\d+)(?:\.(\d+))?\b", flags=re.IGNORECASE)
+_INT_RE = re.compile(r"\b\d+\b")
+
+_UNITS = {
+    0: "null",
+    1: "eins",
+    2: "zwei",
+    3: "drei",
+    4: "vier",
+    5: "fünf",
+    6: "sechs",
+    7: "sieben",
+    8: "acht",
+    9: "neun",
+    10: "zehn",
+    11: "elf",
+    12: "zwölf",
+    13: "dreizehn",
+    14: "vierzehn",
+    15: "fünfzehn",
+    16: "sechzehn",
+    17: "siebzehn",
+    18: "achtzehn",
+    19: "neunzehn",
+}
+
+_TENS = {
+    20: "zwanzig",
+    30: "dreißig",
+    40: "vierzig",
+    50: "fünfzig",
+    60: "sechzig",
+    70: "siebzig",
+    80: "achtzig",
+    90: "neunzig",
+}
+
+_ORDINAL_BASE = {
+    1: "erste",
+    2: "zweite",
+    3: "dritte",
+    4: "vierte",
+    5: "fünfte",
+    6: "sechste",
+    7: "siebte",
+    8: "achte",
+    9: "neunte",
+    10: "zehnte",
+    11: "elfte",
+    12: "zwölfte",
+    13: "dreizehnte",
+    14: "vierzehnte",
+    15: "fünfzehnte",
+    16: "sechzehnte",
+    17: "siebzehnte",
+    18: "achtzehnte",
+    19: "neunzehnte",
+}
+
+
+def _unit_word(value: int, compound: bool = False) -> str:
+    if value == 1:
+        return "ein" if compound else "eins"
+    return _UNITS[value]
+
+
+def number_to_de(value: int) -> str:
+    if value < 0:
+        return "minus " + number_to_de(-value)
+    if value < 20:
+        return _UNITS[value]
+    if value < 100:
+        ones = value % 10
+        tens = value - ones
+        if ones == 0:
+            return _TENS[tens]
+        return f"{_unit_word(ones, compound=True)}und{_TENS[tens]}"
+    if value < 1000:
+        hundreds = value // 100
+        rest = value % 100
+        head = "einhundert" if hundreds == 1 else f"{_unit_word(hundreds, compound=True)}hundert"
+        return head if rest == 0 else head + number_to_de(rest)
+    if value < 1_000_000:
+        thousands = value // 1000
+        rest = value % 1000
+        head = "eintausend" if thousands == 1 else f"{number_to_de(thousands)}tausend"
+        return head if rest == 0 else head + number_to_de(rest)
+    return str(value)
+
+
+def ordinal_to_de(day: int) -> str:
+    if day in _ORDINAL_BASE:
+        return _ORDINAL_BASE[day]
+    if day < 20:
+        return number_to_de(day) + "te"
+    return number_to_de(day) + "ste"
+
+
+def ordinal_date_dative(day: int) -> str:
+    base = ordinal_to_de(day)
+    if base.endswith("e"):
+        return base[:-1] + "en"
+    return base + "n"
+
+
+def _replace_date_parts(day: int, month: int, year: int, *, dative: bool) -> str:
+    month_name = _MONTHS.get(month)
+    if month_name is None:
+        return f"{day}.{month}.{year}"
+    ordinal = ordinal_date_dative(day) if dative else ordinal_to_de(day)
+    return f"{ordinal} {month_name} {number_to_de(year)}"
+
+
+def _replace_date_with_am(match: re.Match[str]) -> str:
+    day = int(match.group(1))
+    month = int(match.group(2))
+    year = int(match.group(3))
+    return "am " + _replace_date_parts(day, month, year, dative=True)
+
+
+def _replace_date(match: re.Match[str]) -> str:
+    day = int(match.group(1))
+    month = int(match.group(2))
+    year = int(match.group(3))
+    return _replace_date_parts(day, month, year, dative=False)
+
+
+def _replace_time(match: re.Match[str]) -> str:
+    hours = int(match.group(1))
+    minutes = int(match.group(2))
+    if minutes == 0:
+        return f"{number_to_de(hours)} uhr"
+    return f"{number_to_de(hours)} uhr {number_to_de(minutes)}"
+
+
+def _replace_euro(match: re.Match[str]) -> str:
+    raw = match.group(1) or match.group(2) or ""
+    normalized = raw.replace(",", ".")
+    if "." in normalized:
+        euros_raw, cents_raw = normalized.split(".", 1)
+        euros = int(euros_raw)
+        cents = int((cents_raw + "0")[:2])
+    else:
+        euros = int(normalized)
+        cents = 0
+    result = f"{number_to_de(euros)} euro"
+    if cents:
+        result += f" und {number_to_de(cents)} cent"
+    return result
+
+
+def _spell_digits(value: str) -> str:
+    return " ".join(number_to_de(int(char)) for char in value if char.isdigit())
+
+
+def _replace_decimal(match: re.Match[str]) -> str:
+    whole = int(match.group(1))
+    frac = match.group(2)
+    return f"{number_to_de(whole)} komma {_spell_digits(frac)}"
+
+
+def _replace_percent(match: re.Match[str]) -> str:
+    number = _replace_decimal(re.match(r"(\d+),(\d+)", match.group(1))) if "," in match.group(1) else number_to_de(int(match.group(1)))
+    return f"{number} prozent"
+
+
+def _replace_unit(match: re.Match[str]) -> str:
+    number_raw = match.group(1)
+    unit_raw = match.group(2).lower()
+    number = _replace_decimal(re.match(r"(\d+),(\d+)", number_raw)) if "," in number_raw else number_to_de(int(number_raw))
+    units = {
+        "km": "kilometer",
+        "kg": "kilogramm",
+        "cm": "zentimeter",
+        "mm": "millimeter",
+        "hz": "hertz",
+        "khz": "kilohertz",
+        "mhz": "megahertz",
+        "ghz": "gigahertz",
+        "gb": "gigabyte",
+        "tb": "terabyte",
+        "mb": "megabyte",
+        "ms": "millisekunden",
+        "s": "sekunden",
+        "m": "meter",
+        "°c": "grad celsius",
+    }
+    return f"{number} {units[unit_raw]}"
+
+
+def _replace_ordinal(match: re.Match[str]) -> str:
+    value = int(match.group(1))
+    return ordinal_to_de(value)
+
+
+def _replace_acronym(match: re.Match[str]) -> str:
+    return _LETTER_ACRONYMS[match.group(0)]
+
+
+def _replace_version(match: re.Match[str]) -> str:
+    major = number_to_de(int(match.group(1)))
+    minor = match.group(2)
+    if minor is None:
+        return f"version {major}"
+    return f"version {major} punkt {_spell_digits(minor)}"
+
+
+def _replace_int(match: re.Match[str]) -> str:
+    raw = match.group(0)
+    try:
+        value = int(raw)
+    except ValueError:
+        return raw
+    if value >= 1_000_000:
+        return raw
+    return number_to_de(value)
+
+
+def normalize_text_de(text: str) -> str:
+    normalized = text
+    for pattern, replacement in _ABBREVIATIONS.items():
+        normalized = re.sub(pattern, replacement, normalized)
+    normalized = _DATE_WITH_AM_RE.sub(_replace_date_with_am, normalized)
+    normalized = _DATE_RE.sub(_replace_date, normalized)
+    normalized = _TIME_RE.sub(_replace_time, normalized)
+    normalized = _EURO_RE.sub(_replace_euro, normalized)
+    normalized = _PERCENT_RE.sub(_replace_percent, normalized)
+    normalized = _UNIT_RE.sub(_replace_unit, normalized)
+    normalized = _DECIMAL_RE.sub(_replace_decimal, normalized)
+    normalized = _VERSION_RE.sub(_replace_version, normalized)
+    normalized = _ORDINAL_RE.sub(_replace_ordinal, normalized)
+    normalized = _ACRONYM_RE.sub(_replace_acronym, normalized)
+    normalized = _INT_RE.sub(_replace_int, normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized

--- a/kokoro_de/overrides.py
+++ b/kokoro_de/overrides.py
@@ -1,0 +1,157 @@
+"""
+Overrides for the German Kokoro frontend.
+
+Priority: BRAND_OVERRIDES > EN_OVERRIDES > DE_FOREIGN
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+EN_OVERRIDES: dict[str, str] = {
+    'accelerate': 'ɐksˈɛlɚɹˌAt',
+    'amd': 'ˌAˌɛmdˈiː',
+    'apache': 'ɐpˈæʧi',
+    'api': 'eɪpiːˈaɪ',
+    'bert': 'bˈɜːt',
+    'checkpoint': 'tʃˈɛkpɔɪnt',
+    'cli': 'tseːɛlˈaɪ',
+    'debian': 'dˈɛbiən',
+    'disneyplus': 'dˈɪzni plˈʌs',
+    'dropout': 'dɹˈɑːpWt',
+    'fallback': 'fˈɔːlbæk',
+    'finetuning': 'fˈIn tˈuːnɪŋ',
+    'gan': 'ɡˈæn',
+    'github': 'ɡˈɪthab',
+    'githubactions': 'ɡˈɪt hˈʌb ˈɛkʃəns',
+    'gpu': 'dʒiːpiːjˈuː',
+    'https': 'ˌAʧtˌiːtˈiːpˌiːˈɛs',
+    'huggingface': 'hˈaɡɪŋfeɪs',
+    'ipad': 'ˈI pˈæd',
+    'jameswebb': 'ʤˈAmz wˈɛb',
+    'json': 'dʒˈeɪsən',
+    'kde': 'kˌAdˌiːˈiː',
+    'louisvuitton': 'lwˈi vyitˈɔ̃',
+    'macos': 'mˈɛk oː ˈɛs',
+    'moetchandon': 'mɔˈɛ ʃɑ̃dˈɔ̃',
+    'nvidia': 'ɛnˈviːdiːa',
+    'ollama': 'olˈaːma',
+    'pipeline': 'pˈaɪplaɪn',
+    'primevideo': 'pɹˈIm vˈɪdɪO',
+    'protocol': 'pʁotokˈɔl',
+    'pytorch': 'pˈaɪtɔːɹtʃ',
+    'rag': 'ɹˈæɡ',
+    'repository': 'ɹᵻpˈɑːzɪtˌɔːɹi',
+    'review': 'ɹᵻvjˈuː',
+    'rnn': 'ˌɑːɹɹˌɛnˈɛn',
+    'runtime': 'ˈɹantaɪm',
+    'styletts': 'stˈaɪl tiːtiːˈɛs',
+    'styletts2': 'stˈaɪl tiːtiːˈɛs tsvai',
+    'surface': 'sˈɜːfɪs',
+    'tcp': 'tˌiːsˌiːpˈiː',
+    'thread': 'θɹˈɛd',
+    'tpu': 'tˌiːpˌiːjˈuː',
+    'transformers': 'tɹænsfˈɔːɹmɚz',
+    'ubuntu': 'uːbˈuːntuː',
+    'ui': 'juːˈaɪ',
+    'wavlm': 'wˈɛɪv ɛlˈɛm',
+    'wsl': 'dˌʌbəljˌuːˌɛsˈɛl',
+    'zero-shot': 'zˈiːɹo ʃˈɔt',
+}
+
+DE_FOREIGN: dict[str, str] = {
+    'diathese': 'diaˈteːzə',
+    'ekstase': 'ɛkstˈaːzə',
+    'epiklese': 'epiˈkleːzə',
+    'epithese': 'epiˈteːzə',
+    'glucose': 'ɡlukˈoːzə',
+    'hypnose': 'hˈyːpnoːzə',
+    'metamorphose': 'metamɔʁfˈoːzə',
+    'oase': 'oˈaːzə',
+    'prosthese': 'pʁɔstˈeːzə',
+    'prothese': 'pʁotˈeːzə',
+    'symbiose': 'zʏmbɪˈoːzə',
+    'synthese': 'zʏntˈeːzə',
+}
+
+BRAND_OVERRIDES: dict[str, str] = {
+    'bark': 'bˈaːɐk',
+    'claude': 'klˈoːt',
+    'coqui': 'kˈoːki',
+    'cuda': 'kˈuːda',
+    'deepseek': 'dˈiːpsiːk',
+    'espeak-ng': 'ˈiːspiːk ɛndʒiː',
+    'fastpitch': 'fˈaːstpɪtʃ',
+    'geforce': 'dʒiːfˈɔɐs',
+    'gemini': 'dʒˈɛmɪnaɪ',
+    'hifigan': 'haɪfˈaɪɡæn',
+    'intellij': 'ˈɪntɛlaɪdʒ',
+    'kikiri': 'kɪkˈiːʁi',
+    'kokoro': 'kˈoːkoːʁoː',
+    'llama': 'lˈaːma',
+    'mistral': 'mˈɪstʁal',
+    'mixtral': 'mˈɪkstʁal',
+    'neovim': 'nˈiːovɪm',
+    'phonemizer': 'foːnəmˈaɪzɐ',
+    'piper': 'pˈaɪpɐ',
+    'pycharm': 'pˈaɪtʃaːɐm',
+    'qwen': 'kwˈɛn',
+    'radeon': 'ɹˈeɪdɪɔn',
+    'ryzen': 'ɹˈaɪzən',
+    'tacotron': 'tˈækotʁɔn',
+    'tacotron2': 'tˈækotʁɔn tuː',
+    'triton': 'tʁˈaɪtɔn',
+    'typescript': 'tˈaɪpskʁɪpt',
+    'unsloth': 'ˈʌnslɔːθ',
+    'vits': 'vˈɪts',
+    'vscode': 'viːˈɛs koːt',
+}
+
+
+def override_for(word: str) -> str | None:
+    key = word.lower().strip()
+    if key in BRAND_OVERRIDES:
+        return BRAND_OVERRIDES[key]
+    if key in EN_OVERRIDES:
+        return EN_OVERRIDES[key]
+    if key in DE_FOREIGN:
+        return DE_FOREIGN[key]
+    normalized = normalize_for_lookup(key)
+    canonical = _NORMALIZED_ALIASES.get(normalized, normalized)
+    return _NORMALIZED_OVERRIDES.get(canonical)
+
+
+def normalize_for_lookup(text: str) -> str:
+    text = unicodedata.normalize("NFKD", text.casefold())
+    parts: list[str] = []
+    replacements = {
+        "+": "plus",
+        "&": "and",
+        "@": "at",
+    }
+    for char in text:
+        if unicodedata.category(char) == "Mn":
+            continue
+        replacement = replacements.get(char)
+        if replacement is not None:
+            parts.append(replacement)
+            continue
+        if char.isalnum():
+            parts.append(char)
+    return "".join(parts)
+
+
+_NORMALIZED_ALIASES: dict[str, str] = {
+    "moetandchandon": "moetchandon",
+}
+
+
+def _build_normalized_overrides() -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for mapping in (BRAND_OVERRIDES, EN_OVERRIDES, DE_FOREIGN):
+        for key, value in mapping.items():
+            normalized.setdefault(normalize_for_lookup(key), value)
+    return normalized
+
+
+_NORMALIZED_OVERRIDES = _build_normalized_overrides()

--- a/kokoro_de/pipeline.py
+++ b/kokoro_de/pipeline.py
@@ -1,0 +1,190 @@
+"""
+KokoroDEPipeline wraps Kokoro's upstream KPipeline with a German override router.
+
+The wrapper stays close to upstream behavior:
+- non-German languages are delegated unchanged,
+- German text is routed through `kokoro_de.Router`,
+- phoneme sequences are split on token boundaries instead of being sliced.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Callable, Generator, Optional, Union
+
+from .router import Router, Token
+
+
+def _load_kpipeline_class():
+    try:
+        from kokoro import KPipeline
+        return KPipeline
+    except ImportError:
+        local_submodule = Path(__file__).resolve().parents[1] / "kokoro"
+        if local_submodule.exists():
+            local_path = str(local_submodule)
+            if local_path not in sys.path:
+                sys.path.insert(0, local_path)
+            from kokoro import KPipeline
+            return KPipeline
+        raise ImportError(
+            "KokoroDEPipeline requires the upstream `kokoro` package. "
+            "Install `kokoro>=0.9.4` or work from a checkout with the `kokoro/` submodule."
+        )
+
+
+class KokoroDEPipeline:
+    """German-aware wrapper for Kokoro's upstream pipeline."""
+
+    def __init__(
+        self,
+        lang_code: str = "d",
+        repo_id: Optional[str] = None,
+        model=None,
+        trf: bool = False,
+        device: Optional[str] = None,
+        router: Optional[Router] = None,
+    ):
+        kpipeline_cls = _load_kpipeline_class()
+        self._base = kpipeline_cls(
+            lang_code=lang_code,
+            repo_id=repo_id,
+            model=model,
+            trf=trf,
+            device=device,
+        )
+        self.lang_code = self._base.lang_code
+        self.model = self._base.model
+        self.voices = self._base.voices
+        self.repo_id = self._base.repo_id
+        self.router = router if self.lang_code == "d" else None
+        if self.lang_code == "d" and self.router is None:
+            self.router = Router()
+
+    def load_voice(self, voice, delimiter=","):
+        return self._base.load_voice(voice, delimiter)
+
+    @property
+    def Result(self):
+        return self._base.Result
+
+    @staticmethod
+    def _render_phoneme_tokens(tokens: list[Token]) -> str:
+        rendered = ""
+        for token in tokens:
+            part = token.phonemes
+            if not part:
+                continue
+            if not rendered:
+                rendered = part
+            elif len(part) == 1 and not part[0].isalnum():
+                rendered += part
+            else:
+                rendered += " " + part
+        return rendered
+
+    @staticmethod
+    def _token_text(tokens: list[Token]) -> str:
+        text = ""
+        for token in tokens:
+            part = token.text
+            if not text:
+                text = part
+            elif len(part) == 1 and part in ".,!?;:%)]}»”":
+                text += part
+            else:
+                text += " " + part
+        return text
+
+    @classmethod
+    def _split_routed_tokens(cls, tokens: list[Token], max_phonemes: int = 510) -> list[tuple[str, str]]:
+        chunks: list[tuple[str, str]] = []
+        current: list[Token] = []
+        last_break_index: int | None = None
+        break_tokens = {".", "!", "?", ":", ";", ","}
+
+        def flush(count: int | None = None):
+            nonlocal current, last_break_index
+            if not current:
+                return
+            use_count = len(current) if count is None else count
+            head = current[:use_count]
+            chunks.append((cls._token_text(head), cls._render_phoneme_tokens(head)))
+            current = current[use_count:]
+            last_break_index = None
+            for index, token in enumerate(current):
+                if token.text in break_tokens:
+                    last_break_index = index + 1
+
+        for token in tokens:
+            current.append(token)
+            if token.text in break_tokens:
+                last_break_index = len(current)
+            rendered = cls._render_phoneme_tokens(current)
+            if len(rendered) <= max_phonemes:
+                continue
+            if len(current) == 1:
+                raise ValueError(
+                    f"Single routed token exceeds Kokoro limit ({len(rendered)} > {max_phonemes}): {token.text!r}"
+                )
+            if last_break_index and last_break_index < len(current):
+                overflow = current[last_break_index:]
+                flush(last_break_index)
+                current = overflow
+            else:
+                overflow = current[-1:]
+                flush(len(current) - 1)
+                current = overflow
+            rendered = cls._render_phoneme_tokens(current)
+            if len(rendered) > max_phonemes:
+                raise ValueError(
+                    f"Single routed token exceeds Kokoro limit ({len(rendered)} > {max_phonemes}): {current[0].text!r}"
+                )
+
+        flush()
+        return [(text, phonemes) for text, phonemes in chunks if phonemes]
+
+    def _german_chunks(self, graphemes: str) -> list[tuple[str, str]]:
+        routed = self.router.route(graphemes)
+        return self._split_routed_tokens(routed)
+
+    def __call__(
+        self,
+        text: Union[str, list[str]],
+        voice: Optional[str] = None,
+        speed: Union[float, Callable] = 1,
+        split_pattern: Optional[str] = r"\n+",
+        model=None,
+    ) -> Generator:
+        if self.router is None:
+            yield from self._base(
+                text,
+                voice=voice,
+                speed=speed,
+                split_pattern=split_pattern,
+                model=model,
+            )
+            return
+
+        model = model or self.model
+        if model and voice is None:
+            raise ValueError('Specify a voice: pipeline(text="Hallo", voice="df_voice")')
+        pack = self.load_voice(voice).to(model.device) if model else None
+
+        if isinstance(text, str):
+            text = re.split(split_pattern, text.strip()) if split_pattern else [text]
+
+        kpipeline_cls = _load_kpipeline_class()
+        for graphemes_index, graphemes in enumerate(text):
+            if not graphemes.strip():
+                continue
+            for chunk_text, chunk_phonemes in self._german_chunks(graphemes):
+                output = kpipeline_cls.infer(model, chunk_phonemes, pack, speed) if model else None
+                yield self._base.Result(
+                    graphemes=chunk_text,
+                    phonemes=chunk_phonemes,
+                    output=output,
+                    text_index=graphemes_index,
+                )

--- a/kokoro_de/router.py
+++ b/kokoro_de/router.py
@@ -1,0 +1,177 @@
+"""
+German TTS frontend with a small override layer on top of espeak-de.
+
+Design goals:
+- Import-safe: no G2P backend is loaded at module import time.
+- Real-world matching: overrides can match `Louis Vuitton`, `Disney+`,
+  `Prime Video`, `GitHub Actions`, etc., not only collapsed forms.
+- Conservative fallback: unknown tokens go straight to the configured G2P.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Protocol
+
+from .normalizer import normalize_text_de
+from .overrides import override_for
+
+_TOKEN = re.compile(
+    r"\d+(?:[.,]\d+)*"
+    r"|[A-Za-zÀ-ÖØ-öø-ÿß]+(?:[-'][A-Za-zÀ-ÖØ-öø-ÿß0-9]+)*"
+    r"|[^\w\s]",
+    flags=re.UNICODE,
+)
+_WORDISH = re.compile(r"[0-9A-Za-zÀ-ÖØ-öø-ÿß]", flags=re.UNICODE)
+_TRAILING_PUNCT = {".", ",", "!", "?", ":", ";", "%", ")", "]", "}", "»", "”"}
+_MATCHABLE_TAILS = {"+", "&", "@", "/"}
+
+
+class G2PCallable(Protocol):
+    def __call__(self, text: str): ...
+
+
+@dataclass(frozen=True)
+class _RawToken:
+    text: str
+    start: int
+    end: int
+
+
+@dataclass
+class Token:
+    text: str
+    phonemes: str
+    is_override: bool = False
+    source: str = "g2p"
+
+
+def tokenize(text: str) -> list[str]:
+    return [m.group(0) for m in _TOKEN.finditer(text)]
+
+
+def _scan_tokens(text: str) -> list[_RawToken]:
+    return [_RawToken(m.group(0), m.start(), m.end()) for m in _TOKEN.finditer(text)]
+
+
+def _is_wordish(text: str) -> bool:
+    return bool(_WORDISH.search(text))
+
+
+def _span_text(text: str, tokens: list[_RawToken], start: int, end: int) -> str:
+    return text[tokens[start].start:tokens[end - 1].end]
+
+
+def _is_matchable_tail(text: str) -> bool:
+    return _is_wordish(text) or text in _MATCHABLE_TAILS
+
+
+def _render_phonemes(parts: list[str]) -> str:
+    rendered = ""
+    for part in parts:
+        if not part:
+            continue
+        if not rendered:
+            rendered = part
+        elif part in _TRAILING_PUNCT:
+            rendered += part
+        else:
+            rendered += " " + part
+    return rendered
+
+
+class Router:
+    def __init__(
+        self,
+        g2p: G2PCallable | None = None,
+        max_phrase_tokens: int = 6,
+        normalizer=normalize_text_de,
+    ):
+        self._g2p = g2p
+        self.max_phrase_tokens = max_phrase_tokens
+        self.normalizer = normalizer
+
+    def _ensure_g2p(self) -> G2PCallable:
+        if self._g2p is None:
+            try:
+                from misaki import espeak
+            except ImportError as exc:
+                raise ImportError(
+                    "Router requires `misaki` for runtime phonemization. "
+                    "Install the project dependencies first."
+                ) from exc
+            self._g2p = espeak.EspeakG2P(language="de")
+        return self._g2p
+
+    def _g2p_phonemes(self, text: str) -> str:
+        result = self._ensure_g2p()(text)
+        if isinstance(result, tuple):
+            return result[0] or ""
+        return result or ""
+
+    def _fallback_token(self, text: str) -> Token:
+        if not _is_wordish(text):
+            return Token(text=text, phonemes=text, is_override=False, source="punct")
+        return Token(
+            text=text,
+            phonemes=self._g2p_phonemes(text),
+            is_override=False,
+            source="g2p",
+        )
+
+    def token(self, word: str) -> Token:
+        ov = override_for(word)
+        if ov is not None:
+            return Token(text=word, phonemes=ov, is_override=True, source="override")
+        return self._fallback_token(word)
+
+    def route(self, text: str) -> list[Token]:
+        text = self.normalizer(text) if self.normalizer else text
+        raw_tokens = _scan_tokens(text)
+        routed: list[Token] = []
+        i = 0
+        while i < len(raw_tokens):
+            matched = False
+            if not _is_wordish(raw_tokens[i].text):
+                routed.append(self._fallback_token(raw_tokens[i].text))
+                i += 1
+                continue
+            max_end = min(len(raw_tokens), i + self.max_phrase_tokens)
+            for end in range(max_end, i, -1):
+                if not _is_matchable_tail(raw_tokens[end - 1].text):
+                    continue
+                span = _span_text(text, raw_tokens, i, end)
+                ov = override_for(span)
+                if ov is None:
+                    continue
+                routed.append(Token(text=span, phonemes=ov, is_override=True, source="override"))
+                i = end
+                matched = True
+                break
+            if matched:
+                continue
+            routed.append(self._fallback_token(raw_tokens[i].text))
+            i += 1
+        return routed
+
+    def phonemize(self, text: str) -> str:
+        return _render_phonemes([token.phonemes for token in self.route(text)])
+
+
+_default_router: Router | None = None
+
+
+def _get_default_router() -> Router:
+    global _default_router
+    if _default_router is None:
+        _default_router = Router()
+    return _default_router
+
+
+def route(text: str) -> list[Token]:
+    return _get_default_router().route(text)
+
+
+def phonemize(text: str) -> str:
+    return _get_default_router().phonemize(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kokoro-deutsch"
-version = "0.1.0"
-description = "Fine-tuning Kokoro-82M for German TTS using StyleTTS2"
+version = "0.3.0"
+description = "German frontend and training utilities for Kokoro TTS"
 readme = "README.md"
 authors = [
     { name="semidark" },
@@ -19,6 +19,7 @@ classifiers = [
 requires-python = ">=3.10, <3.14"
 dependencies = [
     "huggingface_hub",
+    "kokoro>=0.9.4",
     "loguru",
     "misaki[en]>=0.9.4",
     "numpy",
@@ -26,12 +27,8 @@ dependencies = [
     "transformers"
 ]
 
-[project.scripts]
-kokoro = "kokoro.__main__:main"
-
 [tool.hatch.build.targets.wheel]
-only-include = ["kokoro/kokoro"]
-sources = ["kokoro"]
+only-include = ["kokoro_de"]
 only-packages = true
 
 [project.urls]

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import unittest
+
+from kokoro_de import normalize_text_de
+
+
+class NormalizerTests(unittest.TestCase):
+    def test_abbreviation_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Dr. Müller kommt z. B. ca. 3 Min. später."),
+            "Doktor Müller kommt zum beispiel circa drei Min. später.",
+        )
+
+    def test_time_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Treffen um 14:30"),
+            "Treffen um vierzehn uhr dreißig",
+        )
+
+    def test_date_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Termin am 03.05.2026"),
+            "Termin am dritten mai zweitausendsechsundzwanzig",
+        )
+
+    def test_euro_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Kostet 29,99 €"),
+            "Kostet neunundzwanzig euro und neunundneunzig cent",
+        )
+
+    def test_integer_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Es sind 42 Beispiele."),
+            "Es sind zweiundvierzig Beispiele.",
+        )
+
+    def test_decimal_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Wert 3,5 ist okay."),
+            "Wert drei komma fünf ist okay.",
+        )
+
+    def test_percent_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Akku bei 87%."),
+            "Akku bei siebenundachtzig prozent.",
+        )
+
+    def test_unit_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Es sind 12 km und 21°C."),
+            "Es sind zwölf kilometer und einundzwanzig grad celsius.",
+        )
+
+    def test_simple_ordinal_expansion(self):
+        self.assertEqual(
+            normalize_text_de("Der 3. Versuch klappt."),
+            "Der dritte Versuch klappt.",
+        )
+
+    def test_acronym_expansion(self):
+        self.assertEqual(
+            normalize_text_de("AI, TTS und GPU für LLM-Tests."),
+            "a i, t t s und g p u für l l m-Tests.",
+        )
+
+    def test_tech_unit_expansion(self):
+        self.assertEqual(
+            normalize_text_de("24 kHz, 3 ms und 16 GB für v1.2."),
+            "vierundzwanzig kilohertz, drei millisekunden und sechzehn gigabyte für version eins punkt zwei.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import unittest
+
+from kokoro_de import Router, normalize_for_lookup, override_for, phonemize
+
+
+class FakeG2P:
+    def __call__(self, text: str):
+        return f"<{text.casefold()}>"
+
+
+class RouterImportTests(unittest.TestCase):
+    def test_package_level_phonemizer_is_lazy(self):
+        import kokoro_de
+
+        self.assertTrue(hasattr(kokoro_de, "Router"))
+        self.assertTrue(callable(kokoro_de.override_for))
+
+
+class OverrideLookupTests(unittest.TestCase):
+    def test_normalization_collapses_spaces(self):
+        self.assertEqual(normalize_for_lookup("Louis Vuitton"), "louisvuitton")
+        self.assertEqual(override_for("Louis Vuitton"), override_for("louisvuitton"))
+
+    def test_normalization_handles_plus_sign(self):
+        self.assertEqual(normalize_for_lookup("Disney+"), "disneyplus")
+        self.assertEqual(override_for("Disney+"), override_for("disneyplus"))
+
+    def test_normalization_handles_accents_and_ampersands(self):
+        self.assertEqual(normalize_for_lookup("Moët & Chandon"), "moetandchandon")
+        self.assertEqual(override_for("Moët & Chandon"), override_for("moetchandon"))
+
+    def test_phrase_lookup_handles_split_brands(self):
+        self.assertEqual(override_for("Prime Video"), override_for("primevideo"))
+        self.assertEqual(override_for("GitHub Actions"), override_for("githubactions"))
+        self.assertEqual(override_for("James Webb"), override_for("jameswebb"))
+
+
+class RouterBehaviorTests(unittest.TestCase):
+    def setUp(self):
+        self.router = Router(g2p=FakeG2P())
+
+    def test_route_matches_multiword_brands(self):
+        tokens = self.router.route("Louis Vuitton und Disney+.")
+        self.assertEqual(tokens[0].text, "Louis Vuitton")
+        self.assertTrue(tokens[0].is_override)
+        self.assertEqual(tokens[1].phonemes, "<und>")
+        self.assertEqual(tokens[2].text, "Disney+")
+        self.assertTrue(tokens[2].is_override)
+        self.assertEqual(tokens[3].phonemes, ".")
+
+    def test_route_matches_diacritic_phrase(self):
+        tokens = self.router.route("Moët & Chandon bleibt teuer.")
+        self.assertEqual(tokens[0].text, "Moët & Chandon")
+        self.assertTrue(tokens[0].is_override)
+
+    def test_phonemize_keeps_sentence_punctuation_tight(self):
+        rendered = self.router.phonemize("Hallo, Disney+!")
+        self.assertTrue(rendered.endswith("!"))
+        self.assertIn(",", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -457,11 +457,29 @@ wheels = [
 ]
 
 [[package]]
+name = "kokoro"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "misaki", extra = ["en"] },
+    { name = "numpy" },
+    { name = "torch" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/48/88b8cdf28b068d070195c2817175549dee48e7682e3ab8994bee5f69217e/kokoro-0.9.4.tar.gz", hash = "sha256:fbf633262797f8cf46fdac3315cf9cade67dc8b762c0feccf334892772fb9ac4", size = 26215928, upload-time = "2025-04-05T22:01:35.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/cc/75f41633c75224ba820a4533163bc8b070b6bf25416014074c63284c2d4e/kokoro-0.9.4-py3-none-any.whl", hash = "sha256:a129dc6364a286bd6a92c396e9862459d3d3e45f2c15596ed5a94dcee5789efd", size = 32592, upload-time = "2025-04-05T22:01:23.018Z" },
+]
+
+[[package]]
 name = "kokoro-deutsch"
-version = "0.1.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
+    { name = "kokoro" },
     { name = "loguru" },
     { name = "misaki", extra = ["en"] },
     { name = "numpy" },
@@ -472,6 +490,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "huggingface-hub" },
+    { name = "kokoro", specifier = ">=0.9.4" },
     { name = "loguru" },
     { name = "misaki", extras = ["en"], specifier = ">=0.9.4" },
     { name = "numpy" },


### PR DESCRIPTION
## What changed

Adds a repository-local German normalization layer for important cases such as dates, times, euro amounts, percentages, selected units, ordinals, and common TTS/ML acronyms.

Makes `kokoro_de` import-safe and properly installable as a package.

Improves span-based override matching for real-world spellings such as multi-word brand names and symbol forms.

Adds real unit tests for the frontend layer.

## Validation

- `python3 -m unittest discover -s tests`
